### PR TITLE
Fix example require for application.js in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For Rails applications, add the Squash client engine to your Gemfile with
 JavaScript into your application.js file (or other JavaScript manifest):
 
 ```` javascript
-//= require squash/javascript
+//= require squash_javascript
 ````
 
 ### Other projects


### PR DESCRIPTION
The example in the README is not valid.

``` javascript
//= require squash/javascript
```

The above example should be:

``` javascript
//= require squash_javascript
```
